### PR TITLE
Demo Mode for SeleniumBase

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,13 +201,19 @@ nosetests my_first_test.py --browser=firefox --with-selenium -s
 After the test completes, in the console output you'll see a dot on a new line, representing a passing test. (On test failures you'll see an F instead, and on test errors you'll see an E). It looks more like a moving progress bar when you're running a ton of unit tests side by side. This is part of nosetests. After all tests complete (in this case there is only one), you'll see the "Ran 1 test in ..." line, followed by an "OK" if all nosetests passed.
 
 If the example is moving too fast for your eyes to see what's going on, there are a few things you can do.
-You can add ``--demo_mode`` on the command line, which pauses the browser after each action:
+You can add ``--demo_mode`` on the command line, which pauses the browser for about a second (by default) after each action:
 
 ```bash
 nosetests my_first_test.py --with-selenium -s --demo_mode
 ```
 
-You can also add either of the following to your scripts:
+You can override the default wait time by either updating [settings.py](https://github.com/mdmintz/SeleniumBase/blob/master/seleniumbase/config/settings.py) or by using ``--demo_sleep={NUM}`` when using Demo Mode. (NOTE: If you use ``--demo_sleep={NUM}`` without using ``--demo_mode``, nothing will happen.)
+
+```bash
+nosetests my_first_test.py --with-selenium -s --demo_mode --demo_sleep=1.2
+```
+
+You can also add either of the following to your scripts to slow down the tests:
 
 ```python
 import time; time.sleep(5)  # sleep for 5 seconds (add this after the line you want to pause on)

--- a/README.md
+++ b/README.md
@@ -199,11 +199,19 @@ nosetests my_first_test.py --browser=firefox --with-selenium -s
 ```
 
 After the test completes, in the console output you'll see a dot on a new line, representing a passing test. (On test failures you'll see an F instead, and on test errors you'll see an E). It looks more like a moving progress bar when you're running a ton of unit tests side by side. This is part of nosetests. After all tests complete (in this case there is only one), you'll see the "Ran 1 test in ..." line, followed by an "OK" if all nosetests passed.
-If the example is moving too fast for your eyes to see what's going on, there are 2 things you can do. Add either of the following:
+
+If the example is moving too fast for your eyes to see what's going on, there are a few things you can do.
+You can add ``--demo_mode`` on the command line, which pauses the browser after each action:
+
+```bash
+nosetests my_first_test.py --with-selenium -s --demo_mode
+```
+
+You can also add either of the following to your scripts:
 
 ```python
-import time; time.sleep(5) # sleep for 5 seconds (add this after the line you want to pause on)
-import ipdb; ipdb.set_trace() # waits for your command. n = next line of current method, c = continue, s = step / next executed line (will jump)
+import time; time.sleep(5)  # sleep for 5 seconds (add this after the line you want to pause on)
+import ipdb; ipdb.set_trace()  # waits for your command. n = next line of current method, c = continue, s = step / next executed line (will jump)
 ```
 
 (NOTE: If you're using pytest instead of nosetests and you want to use ipdb in your script for debugging purposes, you'll either need to add "--capture=no" on the command line, or use "import pytest; pytest.set_trace()" instead of using ipdb. More info on that [here](http://stackoverflow.com/questions/2678792/can-i-debug-with-python-debugger-when-using-py-test-somehow).)

--- a/conftest.py
+++ b/conftest.py
@@ -34,6 +34,11 @@ def pytest_addoption(parser):
     parser.addoption('--log_path', dest='log_path',
                      default='logs/',
                      help='Where the log files are saved.')
+    parser.addoption('--demo_mode', action="store_true",
+                      dest='demo_mode',
+                      default=False,
+                      help="""Using this slows down the automation so that
+                           you can see what it's actually doing.""")
 
 
 def pytest_configure(config):
@@ -41,6 +46,7 @@ def pytest_configure(config):
     with_testing_base = config.getoption('with_testing_base')
     browser = config.getoption('browser')
     log_path = config.getoption('log_path')
+    demo_mode = config.getoption('demo_mode')
     data = ''
     if config.getoption('data') is not None:
         data = config.getoption('data')
@@ -52,6 +58,7 @@ def pytest_configure(config):
     config_file.write("data:::%s\n" % data)
     config_file.write("with_testing_base:::%s\n" % with_testing_base)
     config_file.write("log_path:::%s\n" % log_path)
+    config_file.write("demo_mode:::%s\n" % demo_mode)
     config_file.close()
     log_folder_setup(config)
 

--- a/conftest.py
+++ b/conftest.py
@@ -35,10 +35,10 @@ def pytest_addoption(parser):
                      default='logs/',
                      help='Where the log files are saved.')
     parser.addoption('--demo_mode', action="store_true",
-                      dest='demo_mode',
-                      default=False,
-                      help="""Using this slows down the automation so that
-                           you can see what it's actually doing.""")
+                     dest='demo_mode',
+                     default=False,
+                     help="""Using this slows down the automation so that
+                          you can see what it's actually doing.""")
 
 
 def pytest_configure(config):

--- a/conftest.py
+++ b/conftest.py
@@ -39,6 +39,10 @@ def pytest_addoption(parser):
                      default=False,
                      help="""Using this slows down the automation so that
                           you can see what it's actually doing.""")
+    parser.addoption('--demo_sleep', action='store', dest='demo_sleep',
+                     default=None,
+                     help="""Setting this overrides the Demo Mode sleep
+                          time that happens after browser actions.""")
 
 
 def pytest_configure(config):
@@ -47,7 +51,10 @@ def pytest_configure(config):
     browser = config.getoption('browser')
     log_path = config.getoption('log_path')
     demo_mode = config.getoption('demo_mode')
+    demo_sleep = ''
     data = ''
+    if config.getoption('demo_sleep') is not None:
+        demo_sleep = config.getoption('demo_sleep')
     if config.getoption('data') is not None:
         data = config.getoption('data')
     # Create a temporary config file while tests are running
@@ -59,6 +66,7 @@ def pytest_configure(config):
     config_file.write("with_testing_base:::%s\n" % with_testing_base)
     config_file.write("log_path:::%s\n" % log_path)
     config_file.write("demo_mode:::%s\n" % demo_mode)
+    config_file.write("demo_sleep:::%s\n" % demo_sleep)
     config_file.close()
     log_folder_setup(config)
 

--- a/docker/docker_setup.py
+++ b/docker/docker_setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages  # noqa
 
 setup(
     name='seleniumbase',
-    version='1.1.15',
+    version='1.1.16',
     author='Michael Mintz',
     author_email='@mintzworld',
     maintainer='Michael Mintz',

--- a/seleniumbase/config/settings.py
+++ b/seleniumbase/config/settings.py
@@ -10,6 +10,11 @@ SMALL_TIMEOUT = 5
 LARGE_TIMEOUT = 10
 EXTREME_TIMEOUT = 30
 
+# Default time to wait after each browser action performed during Demo Mode
+# Use Demo Mode when you want others to see what your automation is doing
+# Usage: --demo_mode when run from the command line when using --with-selenium
+DEMO_MODE_TIMEOUT = 1.2
+
 # If True, existing logs from past test runs will be saved and take up space.
 # If False, only the logs from the most recent test run will be saved locally.
 # This has no effect on Jenkins/S3/MySQL, which may still be saving test logs.

--- a/seleniumbase/config/settings.py
+++ b/seleniumbase/config/settings.py
@@ -13,7 +13,8 @@ EXTREME_TIMEOUT = 30
 # Default time to wait after each browser action performed during Demo Mode
 # Use Demo Mode when you want others to see what your automation is doing
 # Usage: --demo_mode when run from the command line when using --with-selenium
-DEMO_MODE_TIMEOUT = 1.2
+# This value can be overwritten on the command line by using --demo_sleep=FLOAT
+DEFAULT_DEMO_MODE_TIMEOUT = 1.2
 
 # If True, existing logs from past test runs will be saved and take up space.
 # If False, only the logs from the most recent test run will be saved locally.

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -237,10 +237,14 @@ class BaseCase(unittest.TestCase):
 
     def _demo_mode_pause_if_active(self, tiny=False):
         if self.demo_mode:
-            if not tiny:
-                time.sleep(settings.DEMO_MODE_TIMEOUT)
+            if self.demo_sleep:
+                wait_time = float(self.demo_sleep)
             else:
-                time.sleep(settings.DEMO_MODE_TIMEOUT/3.0)
+                wait_time = settings.DEFAULT_DEMO_MODE_TIMEOUT
+            if not tiny:
+                time.sleep(wait_time)
+            else:
+                time.sleep(wait_time/3.0)
 
     def _demo_mode_scroll_if_active(self, selector, by):
         if self.demo_mode:
@@ -271,6 +275,7 @@ class BaseCase(unittest.TestCase):
             self.browser = pytest.config.option.browser
             self.data = pytest.config.option.data
             self.demo_mode = pytest.config.option.demo_mode
+            self.demo_sleep = pytest.config.option.demo_sleep
             if self.with_selenium:
                 self.driver = browser_launcher.get_driver(self.browser)
 

--- a/seleniumbase/plugins/selenium_plugin.py
+++ b/seleniumbase/plugins/selenium_plugin.py
@@ -51,6 +51,10 @@ class SeleniumBrowser(Plugin):
                           default=False,
                           help="""Using this slows down the automation so that
                                you can see what it's actually doing.""")
+        parser.add_option('--demo_sleep', action='store', dest='demo_sleep',
+                          default=None,
+                          help="""Setting this overrides the Demo Mode sleep
+                               time that happens after browser actions.""")
 
     def configure(self, options, conf):
         super(SeleniumBrowser, self).configure(options, conf)
@@ -101,6 +105,7 @@ class SeleniumBrowser(Plugin):
                     version = ""
                 test.test.browser = "%s%s" % (self.options.browser, version)
                 test.test.demo_mode = self.options.demo_mode
+                test.test.demo_sleep = self.options.demo_sleep
             except Exception as err:
                 print "Error starting/connecting to Selenium:"
                 print err

--- a/seleniumbase/plugins/selenium_plugin.py
+++ b/seleniumbase/plugins/selenium_plugin.py
@@ -46,6 +46,11 @@ class SeleniumBrowser(Plugin):
                           default='4444',
                           help="""Designates the port used by the test.
                                Default: 4444.""")
+        parser.add_option('--demo_mode', action="store_true",
+                          dest='demo_mode',
+                          default=False,
+                          help="""Using this slows down the automation so that
+                               you can see what it's actually doing.""")
 
     def configure(self, options, conf):
         super(SeleniumBrowser, self).configure(options, conf)
@@ -95,6 +100,7 @@ class SeleniumBrowser(Plugin):
                 else:
                     version = ""
                 test.test.browser = "%s%s" % (self.options.browser, version)
+                test.test.demo_mode = self.options.demo_mode
             except Exception as err:
                 print "Error starting/connecting to Selenium:"
                 print err

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages  # noqa
 
 setup(
     name='seleniumbase',
-    version='1.1.15',
+    version='1.1.16',
     url='https://github.com/mdmintz/SeleniumBase',
     author='Michael Mintz',
     author_email='@mintzworld',


### PR DESCRIPTION
Demo Mode allows you to run your SeleniumBase scripts at a slower speed so that your audience has a chance to see what the automation is doing, because otherwise it can move too fast for the human eye.

Usage:
--demo_mode (from the command line)
You can update the default wait in either settings.py or from the command line:
--demo_sleep=1.2
