### PR TITLE
Fix MySQL pytest plugin

### DIFF
--- a/integrations/docker/docker_setup.py
+++ b/integrations/docker/docker_setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages  # noqa
 
 setup(
     name='seleniumbase',
-    version='1.1.30',
+    version='1.1.31',
     author='Michael Mintz',
     author_email='@mintzworld',
     maintainer='Michael Mintz',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages  # noqa
 
 setup(
     name='seleniumbase',
-    version='1.1.30',
+    version='1.1.31',
     url='http://seleniumbase.com',
     author='Michael Mintz',
     author_email='@mintzworld',


### PR DESCRIPTION
There were two issues:
One: The link to log files uploaded to S3 in MySQL wasn't showing up on test failures during pytest runs.
Two: The exception message was missing in MySQL on test failures during pytest runs.