### PR TITLE
Replace deprecated methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ What if your test opens up a new tab/window and now you have more than one page?
 Ex:
 
 ```python
-self.driver.switch_to_window(self.driver.window_handles[1])  # this switches to the new tab
+self.driver.switch_to.window(self.driver.window_handles[1])  # this switches to the new tab
 ```
 
 driver.window_handles is a list that will continually get updated when new windows/tabs appear (index numbering is auto-incrementing from 0, which represents the main window)
@@ -398,10 +398,10 @@ driver.window_handles is a list that will continually get updated when new windo
 Ex:
 
 ```python
-self.driver.switch_to_frame('ContentManagerTextBody_ifr')
+self.driver.switch_to.frame('ContentManagerTextBody_ifr')
 # Now you can act inside the iFrame
 # Do something cool (here)
-self.driver.switch_to_default_content()  # exit the iFrame when you're done
+self.driver.switch_to.default_content()  # exit the iFrame when you're done
 ```
 
 #### Handle Pop-Up Alerts

--- a/examples/test_fail.py
+++ b/examples/test_fail.py
@@ -7,5 +7,5 @@ from seleniumbase import BaseCase
 class MyTestClass(BaseCase):
 
     def test_find_army_of_robots_on_xkcd_desert_island(self):
-        self.driver.get("http://xkcd.com/731/")
-        self.wait_for_element("div#ARMY_OF_ROBOTS", timeout=0.7)
+        self.open("http://xkcd.com/731/")
+        self.find_element("div#ARMY_OF_ROBOTS", timeout=0.7)

--- a/seleniumbase/fixtures/page_actions.py
+++ b/seleniumbase/fixtures/page_actions.py
@@ -340,7 +340,7 @@ def wait_for_and_dismiss_alert(driver, timeout=settings.LARGE_TIMEOUT):
 def wait_for_and_switch_to_alert(driver, timeout=settings.LARGE_TIMEOUT):
     """
     Wait for a browser alert to appear, and switch to it. This should be usable
-    as a drop-in replacement for driver.switch_to_alert() when the alert box
+    as a drop-in replacement for driver.switch_to.alert() when the alert box
     may not exist yet.
     @Params
     driver - the webdriver object (required)
@@ -349,7 +349,7 @@ def wait_for_and_switch_to_alert(driver, timeout=settings.LARGE_TIMEOUT):
 
     for x in range(int(timeout * 10)):
         try:
-            alert = driver.switch_to_alert()
+            alert = driver.switch_to.alert()
             # Raises exception if no alert present
             dummy_variable = alert.text  # noqa
             return alert

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages  # noqa
 
 setup(
     name='seleniumbase',
-    version='1.1.37',
+    version='1.1.38',
     url='http://seleniumbase.com',
     author='Michael Mintz',
     author_email='@mintzworld',


### PR DESCRIPTION
Methods such as self.driver.switch_to_[X] have become self.driver.switch_to.[X]