### PR TITLE
Add the option to save reports for test runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,6 @@ nosetests.xml
 
 # Other
 selenium-server-standalone.jar
+latest_report
+report_archives
 temp

--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ py.test my_first_test.py --with-selenium --with-testing_base --browser=firefox -
 
 (NOTE: The ``--with-testing_base`` plugin gives you full logging on test failures for screenshots, page source, and basic test info.)
 
+The ``--report`` option gives you a fancy report after your test suite completes. (Requires ``--with-testing_base``) (nosetest-only for now)
+
+```bash
+nosetests my_test_suite.py --with-selenium --with-testing_base --report -s
+```
+(Note: You can add ``--hide_report`` to immediately archive the report rather than displaying it after the test suite completes.)
+
 #### **Step 5:** Complete the setup
 
 If you're planning on using the full power of this test framework, there are a few more things you'll want to do:

--- a/examples/my_test_suite.py
+++ b/examples/my_test_suite.py
@@ -1,0 +1,26 @@
+from seleniumbase import BaseCase
+
+
+class MyTestSuite(BaseCase):
+
+    def test_1(self):
+        self.open("http://xkcd.com/1663/")
+        for p in xrange(4):
+            self.click('a[rel="next"]')
+        self.find_text("Algorithms", "div#ctitle", timeout=3)
+
+    def test_2(self):
+        # This test will fail
+        self.open("http://xkcd.com/1675/")
+        raise Exception("FAKE EXCEPTION: This test fails on purpose.")
+
+    def test_3(self):
+        self.open("http://xkcd.com/1406/")
+        self.find_text("Universal Converter Box", "div#ctitle", timeout=3)
+        self.open("http://xkcd.com/608/")
+        self.find_text("Form", "div#ctitle", timeout=3)
+
+    def test_4(self):
+        # This test will fail
+        self.open("http://xkcd.com/1670/")
+        self.find_element("FakeElement.DoesNotExist", timeout=0.5)

--- a/examples/my_test_suite.py
+++ b/examples/my_test_suite.py
@@ -5,6 +5,7 @@ class MyTestSuite(BaseCase):
 
     def test_1(self):
         self.open("http://xkcd.com/1663/")
+        self.find_text("Garden", "div#ctitle", timeout=3)
         for p in xrange(4):
             self.click('a[rel="next"]')
         self.find_text("Algorithms", "div#ctitle", timeout=3)

--- a/seleniumbase/config/settings.py
+++ b/seleniumbase/config/settings.py
@@ -26,9 +26,17 @@ ARCHIVE_EXISTING_LOGS = False
 
 # Default names for files saved during test failures when logging is turned on.
 # (These files will get saved to the "logs/" folder)
+# Usage: "--with-testing_base"
 SCREENSHOT_NAME = "screenshot.jpg"
 BASIC_INFO_NAME = "basic_test_info.txt"
 PAGE_SOURCE_NAME = "page_source.html"
+
+# Default names for folders and files saved when reports are turned on.
+# Usage: "--report" (Also requires: "--with-testing_base")
+LATEST_REPORT_DIR = "latest_report"
+REPORT_ARCHIVE_DIR = "report_archives"
+HTML_REPORT = "report.html"
+RESULTS_TABLE = "results_table.csv"
 
 ''' This adds wait_for_ready_state_complete() after various browser actions.
     By default, Selenium waits for the 'interactive' state before continuing.
@@ -42,14 +50,7 @@ WAIT_FOR_RSC_ON_CLICKS = False
 
 
 # #####>>>>>----- RECOMMENDED SETTINGS -----<<<<<#####
-# ##### (For test logging and database reporting)
-
-# Amazon S3 Bucket Credentials
-# (For saving screenshots and other log files from tests)
-S3_LOG_BUCKET = "[S3 BUCKET NAME]"
-S3_BUCKET_URL = "https://[S3 BUCKET NAME].s3.amazonaws.com/"
-S3_SELENIUM_ACCESS_KEY = "[S3 ACCESS KEY]"
-S3_SELENIUM_SECRET_KEY = "[S3 SECRET KEY]"
+# ##### (For database reporting and saving test logs)
 
 # MySQL DB Credentials
 # (For saving data from tests)
@@ -57,6 +58,14 @@ DB_HOST = "[TEST DB HOST]"  # Ex: "127.0.0.1"
 DB_USERNAME = "[TEST DB USERNAME]"  # Ex: "root"
 DB_PASSWORD = "[TEST DB PASSWORD]"  # Ex: "test"
 DB_SCHEMA = "[TEST DB SCHEMA]"  # Ex: "test"
+
+
+# Amazon S3 Bucket Credentials
+# (For saving screenshots and other log files from tests)
+S3_LOG_BUCKET = "[S3 BUCKET NAME]"
+S3_BUCKET_URL = "https://[S3 BUCKET NAME].s3.amazonaws.com/"
+S3_SELENIUM_ACCESS_KEY = "[S3 ACCESS KEY]"
+S3_SELENIUM_SECRET_KEY = "[S3 SECRET KEY]"
 
 
 # #####>>>>>----- OPTIONAL SETTINGS -----<<<<<#####

--- a/seleniumbase/core/report_helper.py
+++ b/seleniumbase/core/report_helper.py
@@ -1,0 +1,220 @@
+import os
+import shutil
+import sys
+import time
+from selenium import webdriver
+from seleniumbase.config import settings
+from seleniumbase.core.style_sheet import style
+from seleniumbase.fixtures import page_actions
+
+LATEST_REPORT_DIR = settings.LATEST_REPORT_DIR
+ARCHIVE_DIR = settings.REPORT_ARCHIVE_DIR
+HTML_REPORT = settings.HTML_REPORT
+RESULTS_TABLE = settings.RESULTS_TABLE
+
+
+def get_timestamp():
+    return str(int(time.time() * 1000))
+
+
+def process_successes(test, test_count):
+    return(
+        '"%s","%s","%s","%s","%s","%s","%s","%s","%s"' % (
+            test_count,
+            "Success",
+            "-",
+            "-",
+            "-",
+            test.browser,
+            get_timestamp()[:-3],
+            test.id(),
+            "*"))
+
+
+def process_failures(test, err, test_count, browser_type):
+    bad_page_image = "failure_test_%s.jpg" % test_count
+    bad_page_data = "failure_test_%s.txt" % test_count
+    page_actions.save_screenshot(
+        test.driver, bad_page_image, folder=LATEST_REPORT_DIR)
+    page_actions.save_test_failure_data(
+        test.driver, bad_page_data, browser_type, folder=LATEST_REPORT_DIR)
+    exc_info = '(Unknown Failure)'
+    if sys.exc_info()[1]:
+        exc_info = sys.exc_info()[1]
+        if hasattr(exc_info, 'message'):
+            exc_info = exc_info.message
+    return(
+        '"%s","%s","%s","%s","%s","%s","%s","%s","%s"' % (
+            test_count,
+            "FAILED!",
+            bad_page_data,
+            bad_page_image,
+            test.driver.current_url,
+            test.browser,
+            get_timestamp()[:-3],
+            test.id(),
+            exc_info))
+
+
+def clear_out_old_report_logs(archive_past_runs=True, get_log_folder=False):
+        abs_path = os.path.abspath('.')
+        file_path = abs_path + "/%s" % LATEST_REPORT_DIR
+        if not os.path.exists(file_path):
+            os.makedirs(file_path)
+
+        if archive_past_runs:
+            archive_timestamp = int(time.time())
+            if not os.path.exists("%s/../%s/" % (file_path, ARCHIVE_DIR)):
+                os.makedirs("%s/../%s/" % (file_path, ARCHIVE_DIR))
+            archive_dir = "%s/../%s/report_%s" % (
+                file_path, ARCHIVE_DIR, archive_timestamp)
+            shutil.move(file_path, archive_dir)
+            os.makedirs(file_path)
+            if get_log_folder:
+                return archive_dir
+        else:
+            # Just delete bad pages to make room for the latest run.
+            filelist = [f for f in os.listdir(
+                "./%s" % LATEST_REPORT_DIR) if f.startswith("failure_") or (
+                f == HTML_REPORT) or (f.startswith("automation_failure")) or (
+                f == RESULTS_TABLE)]
+            for f in filelist:
+                os.remove("%s/%s" % (file_path, f))
+
+
+def add_bad_page_log_file(page_results_list):
+    abs_path = os.path.abspath('.')
+    file_path = abs_path + "/%s" % LATEST_REPORT_DIR
+    log_file = "%s/%s" % (file_path, RESULTS_TABLE)
+    f = open(log_file, 'w')
+    h_p1 = '''"Num","Result","Failure Info","Screenshot",'''
+    h_p2 = '''"URL","Browser","Epoch Time",'''
+    h_p3 = '''"Test Case Address","Additional Info"\n'''
+    page_header = h_p1 + h_p2 + h_p3
+    f.write(page_header)
+    for line in page_results_list:
+        f.write("%s\n" % line)
+    f.close()
+
+
+def archive_new_report_logs():
+    log_string = clear_out_old_report_logs(get_log_folder=True)
+    log_folder = log_string.split('/')[-1]
+    abs_path = os.path.abspath('.')
+    file_path = abs_path + "/%s" % ARCHIVE_DIR
+    report_log_path = "%s/%s" % (file_path, log_folder)
+    return report_log_path
+
+
+def add_results_page(html):
+    abs_path = os.path.abspath('.')
+    file_path = abs_path + "/%s" % LATEST_REPORT_DIR
+    results_file_name = HTML_REPORT
+    results_file = "%s/%s" % (file_path, results_file_name)
+    f = open(results_file, 'w')
+    f.write(html)
+    f.close()
+    return results_file
+
+
+def build_report(report_log_path, page_results_list,
+                 successes, failures, browser_type,
+                 hide_report):
+
+    web_log_path = "file://%s" % report_log_path
+    successes_count = len(successes)
+    failures_count = len(failures)
+    total_test_count = successes_count + failures_count
+
+    tf_color = "#11BB11"
+    if failures_count > 0:
+        tf_color = "#EE3A3A"
+
+    new_data = '''<div><table><thead><tr><th>TEST REPORT SUMMARY
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        </th><th></th></tr></thead><tbody>
+        <tr style="color:#00BB00"><td>TESTS PASSING: <td>%s</tr>
+        <tr style="color:%s">     <td>TESTS FAILING: <td>%s</tr>
+        <tr style="color:#4D4DDD"><td>TOTAL TESTS RUN: <td>%s</tr>
+        </tbody></table>''' % (successes_count,
+                               tf_color,
+                               failures_count,
+                               total_test_count)
+
+    new_view_1 = '''<h1 id="ContextHeader" class="sectionHeader" title="">
+        %s</h1>''' % new_data
+
+    log_link_shown = '../%s%s/' % (
+        ARCHIVE_DIR, web_log_path.split(ARCHIVE_DIR)[1])
+    csv_link = '%s/%s' % (web_log_path, RESULTS_TABLE)
+    csv_link_shown = '%s' % RESULTS_TABLE
+    new_view_2 = '''<p><p><p><p><h2><table><tbody>
+        <tr><td>LOG FILES LINK:&nbsp;&nbsp;<td><a href="%s">%s</a></tr>
+        <tr><td>RESULTS TABLE:&nbsp;&nbsp;<td><a href="%s">%s</a></tr>
+        </tbody></table></h2><p><p><p><p>''' % (
+        web_log_path, log_link_shown, csv_link, csv_link_shown)
+
+    new_view_3 = '<h2><table><tbody></div>'
+    any_screenshots = False
+    for line in page_results_list:
+        line = line.split(',')
+        if line[1] == '"FAILED!"':
+            if not any_screenshots:
+                any_screenshots = True
+                new_view_3 += '''<thead><tr>
+                    <th>FAILURE DATA&nbsp;&nbsp;</th>
+                    <th>SCREENSHOT&nbsp;&nbsp;</th>
+                    <th>LOCATION OF FAILURE</th>
+                    </tr></thead>'''
+            line = '<a href="%s">%s</a>' % (
+                "file://" + report_log_path + '/' + line[2], line[2]) + '''
+                &nbsp;&nbsp;
+                ''' + '<td><a href="%s">%s</a>' % (
+                "file://" + report_log_path + '/' + line[3], line[3]) + '''
+                &nbsp;&nbsp;
+                ''' + '<td><a href="%s">%s</a>' % (line[4], line[4])
+            line = line.replace('"', '')
+            new_view_3 += '<tr><td>%s</tr>\n' % line
+    new_view_3 += '</tbody></table></h2>'
+
+    new_view_4 = ''
+    if failures:
+        new_view_4 = '<h2><table><tbody>'
+        new_view_4 += '''<thead><tr><th>LIST OF FAILING TESTS
+                        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                        </th></tr></thead>'''
+        for failure in failures:
+            new_view_4 += '<tr style="color:#EE3A3A"><td>%s</tr>\n' % failure
+        new_view_4 += '</tbody></table></h2>'
+
+    new_view_5 = ''
+    if successes:
+        new_view_5 = '<h2><table><tbody>'
+        new_view_5 += '''<thead><tr><th>LIST OF PASSING TESTS
+                        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                        </th></tr></thead>'''
+        for success in successes:
+            new_view_5 += '<tr style="color:#00BB00"><td>%s</tr>\n' % success
+        new_view_5 += '</tbody></table></h2>'
+
+    new_view = '%s%s%s%s%s' % (
+        new_view_1, new_view_2, new_view_3, new_view_4, new_view_5)
+    results_content = '<body>%s</body>' % new_view
+    new_source = '<html><head>%s</head>%s</html>' % (
+        style, results_content)
+    results_file = add_results_page(new_source)
+    archived_results_file = report_log_path + '/' + HTML_REPORT
+    shutil.copyfile(results_file, archived_results_file)
+    print "\n* The latest html report page is located at:\n" + results_file
+    print "\n* Files saved for this report are located at:\n" + report_log_path
+    print ""
+    if not hide_report:
+        if browser_type == 'chrome':
+            browser = webdriver.Chrome()
+        else:
+            browser = webdriver.Firefox()
+        browser.get("file://%s" % archived_results_file)
+        print "\n*** Close the html report window to continue. ***"
+        while len(browser.window_handles):
+            time.sleep(0.1)
+        browser.quit()

--- a/seleniumbase/core/style_sheet.py
+++ b/seleniumbase/core/style_sheet.py
@@ -1,0 +1,95 @@
+style = '''<meta id="OGTitle" property="og:title" content="SeleniumBase">
+        <title>Test Report</title>
+        <link rel="SHORTCUT ICON"
+        href="http://cdn2.hubspot.net/hubfs/100006/images/results_logo4.ico" />
+        <style type="text/css">
+        html {
+            background-color: #9988ad;
+        }
+        html, body {
+            font-size: 100%;
+            box-sizing: border-box;
+        }
+        body {
+            background-image: none;
+            background-origin: padding-box;
+            background-color: #ecf2ff;
+            padding: 30;
+            margin: 10;
+            font-family: "Proxima Nova","proxima-nova",
+            "Helvetica Neue",Helvetica,Arial,sans-serif !important;
+            text-rendering: optimizelegibility;
+            -moz-osx-font-smoothing: grayscale;
+            box-shadow: 0px 2px 5px 1px rgba(0, 0, 0, 0.24),
+            1px 2px 12px 0px rgba(0, 0, 0, 0.18) !important;
+        }
+        table {
+            border-collapse: collapse;
+            border-spacing: 0;
+            box-shadow: 0px 2px 5px 1px rgba(0, 0, 0, 0.25),
+            1px 2px 12px 0px rgba(0, 0, 0, 0.19) !important;
+            transition: all 0.15s ease-out 0s;
+            transition-property: all;
+            transition-duration: 0.1s;
+            transition-timing-function: ease-out;
+            transition-delay: 0s;
+        }
+        table:hover {
+            box-shadow: 0px 2px 5px 1px rgba(0, 0, 0, 0.35),
+            1px 2px 12px 0px rgba(0, 0, 0, 0.28) !important;
+        }
+        thead th, thead td {
+            padding: 0.5rem 0.625rem 0.625rem;
+            font-weight: bold;
+            text-align: left;
+        }
+        thead {
+            text-align: center;
+            border: 1px solid #e1e1e1;
+            background-color: #fefefe;
+            width: 150%;
+            color: #0C8CDB;
+            background-color: #cbf2ff;
+        }
+        tbody tr:nth-child(even) {
+            background-color: #f1f1f1;
+        }
+        tbody tr:nth-child(odd) {
+            background-color: #ffffff;
+        }
+        tbody tr:nth-child(even):hover {
+            background-color: #f8f8d2;
+        }
+        tbody tr:nth-child(odd):hover {
+            background-color: #ffffe0;
+        }
+        tbody th, tbody td {
+            padding: 0.5rem 0.625rem 0.625rem;
+        }
+        tbody {
+            border: 1px solid #e1e1e1;
+            background-color: #fefefe;
+        }
+        td {
+            padding: 5px 5px 5px 0;
+            vertical-align: top;
+        }
+        h1 table {
+            font-size: 27px;
+            text-align: left;
+            padding: 0.5rem 0.625rem 0.625rem;
+            font-weight: bold;
+            padding-right: 10px;
+            padding-left: 20px;
+            padding: 15px 15px 15px 0;
+        }
+        h2 table {
+            color: #0C8CDB;
+            font-size: 16px;
+            text-align: left;
+            font-weight: bold;
+            padding: 5px 5px 5px 0;
+            padding-right: 10px;
+            padding-left: 20px;
+        }
+        </style>'''

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -24,10 +24,10 @@ from seleniumbase.core.testcase_manager import TestcaseManager
 from seleniumbase.core import browser_launcher
 from seleniumbase.core import log_helper
 from seleniumbase.fixtures import constants
+from seleniumbase.fixtures import page_actions
+from seleniumbase.fixtures import page_utils
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.common.by import By
-import page_actions
-import page_utils
 
 
 class BaseCase(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages  # noqa
 
 setup(
     name='seleniumbase',
-    version='1.1.39',
+    version='1.1.40',
     url='http://seleniumbase.com',
     author='Michael Mintz',
     author_email='@mintzworld',


### PR DESCRIPTION
Usage: "--report" (Also requires: "--with-testing_base")
This will create an html report page after tests finish running.
The report contains detailed test info, a table of tests run, screenshots, etc.
Adding "--hide_report" will archive the report rather than displaying it after the test suite completes.