### PR TITLE
Revamp framework

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pip>=8.1.2
+setuptools>=18.5
 selenium>=2.53.2
 nose==1.3.7
 pytest==2.9.1
@@ -11,5 +12,5 @@ chardet==2.3.0
 simplejson==3.8.2
 boto==2.40.0
 ipdb==0.10.0
-pyvirtualdisplay==0.1.5
+pyvirtualdisplay==0.2
 -e .

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -341,10 +341,12 @@ class BaseCase(unittest.TestCase):
         return self.wait_for_element_visible(selector, by=by, timeout=timeout)
 
     def assert_element(self, selector, by=By.CSS_SELECTOR,
-                       timeout=settings.LARGE_TIMEOUT):
+                       timeout=settings.SMALL_TIMEOUT):
         """ Similar to wait_for_element_visible(), but returns nothing.
-            As above, will raise an exception if nothing can be found. """
+            As above, will raise an exception if nothing can be found.
+            Returns True if successful. Default timeout = SMALL_TIMEOUT. """
         self.wait_for_element_visible(selector, by=by, timeout=timeout)
+        return True
 
     # For backwards compatibility, earlier method names of the next
     # four methods have remained even though they do the same thing,
@@ -371,10 +373,12 @@ class BaseCase(unittest.TestCase):
             text, selector, by=by, timeout=timeout)
 
     def assert_text(self, text, selector, by=By.CSS_SELECTOR,
-                    timeout=settings.LARGE_TIMEOUT):
+                    timeout=settings.SMALL_TIMEOUT):
         """ Similar to wait_for_text_visible(), but returns nothing.
-            As above, will raise an exception if nothing can be found. """
+            As above, will raise an exception if nothing can be found.
+            Returns True if successful. Default timeout = SMALL_TIMEOUT. """
         self.wait_for_text_visible(text, selector, by=by, timeout=timeout)
+        return True
 
     # For backwards compatibility, earlier method names of the next
     # four methods have remained even though they do the same thing,
@@ -394,10 +398,12 @@ class BaseCase(unittest.TestCase):
         """ Same as wait_for_link_text_visible() - returns the element """
         return self.wait_for_link_text_visible(link_text, timeout=timeout)
 
-    def assert_link_text(self, link_text, timeout=settings.LARGE_TIMEOUT):
+    def assert_link_text(self, link_text, timeout=settings.SMALL_TIMEOUT):
         """ Similar to wait_for_link_text_visible(), but returns nothing.
-            As above, will raise an exception if nothing can be found. """
+            As above, will raise an exception if nothing can be found.
+            Returns True if successful. Default timeout = SMALL_TIMEOUT. """
         self.wait_for_link_text_visible(link_text, timeout=timeout)
+        return True
 
     ############
 
@@ -413,9 +419,12 @@ class BaseCase(unittest.TestCase):
             self.driver, selector, by, timeout)
 
     def assert_element_absent(self, selector, by=By.CSS_SELECTOR,
-                              timeout=settings.LARGE_TIMEOUT):
+                              timeout=settings.SMALL_TIMEOUT):
         """ Similar to wait_for_element_absent() - returns nothing.
-            As above, will raise an exception if the element stays present. """
+            As above, will raise an exception if the element stays present.
+            Returns True if successful. Default timeout = SMALL_TIMEOUT. """
+        self.wait_for_element_absent(selector, by=by, timeout=timeout)
+        return True
 
     ############
 
@@ -430,9 +439,12 @@ class BaseCase(unittest.TestCase):
             self.driver, selector, by, timeout)
 
     def assert_element_not_visible(self, selector, by=By.CSS_SELECTOR,
-                                   timeout=settings.LARGE_TIMEOUT):
+                                   timeout=settings.SMALL_TIMEOUT):
         """ Similar to wait_for_element_not_visible() - returns nothing.
-            As above, will raise an exception if the element stays visible. """
+            As above, will raise an exception if the element stays visible.
+            Returns True if successful. Default timeout = SMALL_TIMEOUT. """
+        self.wait_for_element_not_visible(selector, by=by, timeout=timeout)
+        return True
 
     ############
 

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -309,13 +309,22 @@ class BaseCase(unittest.TestCase):
 
     def wait_for_element_present(self, selector, by=By.CSS_SELECTOR,
                                  timeout=settings.LARGE_TIMEOUT):
+        """ Waits for an element to appear in the HTML of a page.
+            The element does not need be visible (it may be hidden). """
         if selector.startswith('/') or selector.startswith('./'):
             by = By.XPATH
         return page_actions.wait_for_element_present(
             self.driver, selector, by, timeout)
 
+    # For backwards compatibility, earlier method names of the next
+    # four methods have remained even though they do the same thing,
+    # with the exception of assert_*, which won't return the element,
+    # but like the others, will raise an exception if the call fails.
+
     def wait_for_element_visible(self, selector, by=By.CSS_SELECTOR,
                                  timeout=settings.LARGE_TIMEOUT):
+        """ Waits for an element to appear in the HTML of a page.
+            The element must be visible (it cannot be hidden). """
         if selector.startswith('/') or selector.startswith('./'):
             by = By.XPATH
         return page_actions.wait_for_element_visible(
@@ -328,8 +337,19 @@ class BaseCase(unittest.TestCase):
 
     def find_element(self, selector, by=By.CSS_SELECTOR,
                      timeout=settings.LARGE_TIMEOUT):
-        """ Same as wait_for_element_visible() """
+        """ Same as wait_for_element_visible() - returns the element """
         return self.wait_for_element_visible(selector, by=by, timeout=timeout)
+
+    def assert_element(self, selector, by=By.CSS_SELECTOR,
+                       timeout=settings.LARGE_TIMEOUT):
+        """ Similar to wait_for_element_visible(), but returns nothing.
+            As above, will raise an exception if nothing can be found. """
+        self.wait_for_element_visible(selector, by=by, timeout=timeout)
+
+    # For backwards compatibility, earlier method names of the next
+    # four methods have remained even though they do the same thing,
+    # with the exception of assert_*, which won't return the element,
+    # but like the others, will raise an exception if the call fails.
 
     def wait_for_text_visible(self, text, selector, by=By.CSS_SELECTOR,
                               timeout=settings.LARGE_TIMEOUT):
@@ -346,9 +366,20 @@ class BaseCase(unittest.TestCase):
 
     def find_text(self, text, selector, by=By.CSS_SELECTOR,
                   timeout=settings.LARGE_TIMEOUT):
-        """ Same as wait_for_text_visible() """
+        """ Same as wait_for_text_visible() - returns the element """
         return self.wait_for_text_visible(
             text, selector, by=by, timeout=timeout)
+
+    def assert_text(self, text, selector, by=By.CSS_SELECTOR,
+                    timeout=settings.LARGE_TIMEOUT):
+        """ Similar to wait_for_text_visible(), but returns nothing.
+            As above, will raise an exception if nothing can be found. """
+        self.wait_for_text_visible(text, selector, by=by, timeout=timeout)
+
+    # For backwards compatibility, earlier method names of the next
+    # four methods have remained even though they do the same thing,
+    # with the exception of assert_*, which won't return the element,
+    # but like the others, will raise an exception if the call fails.
 
     def wait_for_link_text_visible(self, link_text,
                                    timeout=settings.LARGE_TIMEOUT):
@@ -360,22 +391,50 @@ class BaseCase(unittest.TestCase):
         return self.wait_for_link_text_visible(link_text, timeout=timeout)
 
     def find_link_text(self, link_text, timeout=settings.LARGE_TIMEOUT):
-        """ Same as wait_for_link_text_visible() """
+        """ Same as wait_for_link_text_visible() - returns the element """
         return self.wait_for_link_text_visible(link_text, timeout=timeout)
+
+    def assert_link_text(self, link_text, timeout=settings.LARGE_TIMEOUT):
+        """ Similar to wait_for_link_text_visible(), but returns nothing.
+            As above, will raise an exception if nothing can be found. """
+        self.wait_for_link_text_visible(link_text, timeout=timeout)
+
+    ############
 
     def wait_for_element_absent(self, selector, by=By.CSS_SELECTOR,
                                 timeout=settings.LARGE_TIMEOUT):
+        """ Waits for an element to no longer appear in the HTML of a page.
+            A hidden element still counts as appearing in the page HTML.
+            If an element with "hidden" status is acceptable,
+            use wait_for_element_not_visible() instead. """
         if selector.startswith('/') or selector.startswith('./'):
             by = By.XPATH
         return page_actions.wait_for_element_absent(
             self.driver, selector, by, timeout)
 
+    def assert_element_absent(self, selector, by=By.CSS_SELECTOR,
+                              timeout=settings.LARGE_TIMEOUT):
+        """ Similar to wait_for_element_absent() - returns nothing.
+            As above, will raise an exception if the element stays present. """
+
+    ############
+
     def wait_for_element_not_visible(self, selector, by=By.CSS_SELECTOR,
                                      timeout=settings.LARGE_TIMEOUT):
+        """ Waits for an element to no longer be visible on a page.
+            The element can be non-existant in the HTML or hidden on the page
+            to qualify as not visible. """
         if selector.startswith('/') or selector.startswith('./'):
             by = By.XPATH
         return page_actions.wait_for_element_not_visible(
             self.driver, selector, by, timeout)
+
+    def assert_element_not_visible(self, selector, by=By.CSS_SELECTOR,
+                                   timeout=settings.LARGE_TIMEOUT):
+        """ Similar to wait_for_element_not_visible() - returns nothing.
+            As above, will raise an exception if the element stays visible. """
+
+    ############
 
     def wait_for_ready_state_complete(self, timeout=settings.EXTREME_TIMEOUT):
         return page_actions.wait_for_ready_state_complete(self.driver, timeout)

--- a/seleniumbase/fixtures/page_actions.py
+++ b/seleniumbase/fixtures/page_actions.py
@@ -267,7 +267,7 @@ def wait_for_element_absent(driver, selector, by=By.CSS_SELECTOR,
                 break
             time.sleep(0.1)
         except Exception:
-            return
+            return True
     raise Exception("Element [%s] was still present after %s seconds!" %
                     (selector, timeout))
 
@@ -296,9 +296,9 @@ def wait_for_element_not_visible(driver, selector, by=By.CSS_SELECTOR,
                     break
                 time.sleep(0.1)
             else:
-                return
+                return True
         except Exception:
-            return
+            return True
     raise Exception(
         "Element [%s] was still visible after %s seconds!" % (
             selector, timeout))

--- a/seleniumbase/fixtures/page_actions.py
+++ b/seleniumbase/fixtures/page_actions.py
@@ -109,6 +109,8 @@ def hover_and_click(driver, hover_selector, click_selector,
     click_by - the method to search by (Default: By.CSS_SELECTOR)
     timeout - number of seconds to wait for click element to appear after hover
     """
+    start_ms = time.time() * 1000.0
+    stop_ms = start_ms + (timeout * 1000.0)
     driver.execute_script("jQuery('%s').mouseover()" % (hover_selector))
     for x in range(int(timeout * 10)):
         try:
@@ -116,6 +118,9 @@ def hover_and_click(driver, hover_selector, click_selector,
                                           value="%s" % click_selector).click()
             return element
         except Exception:
+            now_ms = time.time() * 1000.0
+            if now_ms >= stop_ms:
+                break
             time.sleep(0.1)
     raise NoSuchElementException(
         "Element [%s] was not present after %s seconds!" %
@@ -139,11 +144,16 @@ def wait_for_element_present(driver, selector, by=By.CSS_SELECTOR,
     """
 
     element = None
+    start_ms = time.time() * 1000.0
+    stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
         try:
             element = driver.find_element(by=by, value=selector)
             return element
         except Exception:
+            now_ms = time.time() * 1000.0
+            if now_ms >= stop_ms:
+                break
             time.sleep(0.1)
     if not element:
         raise NoSuchElementException(
@@ -169,6 +179,8 @@ def wait_for_element_visible(driver, selector, by=By.CSS_SELECTOR,
     """
 
     element = None
+    start_ms = time.time() * 1000.0
+    stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
         try:
             element = driver.find_element(by=by, value=selector)
@@ -178,6 +190,9 @@ def wait_for_element_visible(driver, selector, by=By.CSS_SELECTOR,
                 element = None
                 raise Exception()
         except Exception:
+            now_ms = time.time() * 1000.0
+            if now_ms >= stop_ms:
+                break
             time.sleep(0.1)
     if not element and by != By.LINK_TEXT:
         raise ElementNotVisibleException(
@@ -207,6 +222,8 @@ def wait_for_text_visible(driver, text, selector, by=By.CSS_SELECTOR,
     """
 
     element = None
+    start_ms = time.time() * 1000.0
+    stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
         try:
             element = driver.find_element(by=by, value=selector)
@@ -217,6 +234,9 @@ def wait_for_text_visible(driver, text, selector, by=By.CSS_SELECTOR,
                     element = None
                     raise Exception()
         except Exception:
+            now_ms = time.time() * 1000.0
+            if now_ms >= stop_ms:
+                break
             time.sleep(0.1)
     if not element:
         raise ElementNotVisibleException(
@@ -237,9 +257,14 @@ def wait_for_element_absent(driver, selector, by=By.CSS_SELECTOR,
     timeout - the time to wait for elements in seconds
     """
 
+    start_ms = time.time() * 1000.0
+    stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
         try:
             driver.find_element(by=by, value=selector)
+            now_ms = time.time() * 1000.0
+            if now_ms >= stop_ms:
+                break
             time.sleep(0.1)
         except Exception:
             return
@@ -260,10 +285,15 @@ def wait_for_element_not_visible(driver, selector, by=By.CSS_SELECTOR,
     timeout - the time to wait for the element in seconds
     """
 
+    start_ms = time.time() * 1000.0
+    stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
         try:
             element = driver.find_element(by=by, value=selector)
             if element.is_displayed():
+                now_ms = time.time() * 1000.0
+                if now_ms >= stop_ms:
+                    break
                 time.sleep(0.1)
             else:
                 return
@@ -347,11 +377,16 @@ def wait_for_ready_state_complete(driver, timeout=settings.EXTREME_TIMEOUT):
     This method will wait until document.readyState == "complete".
     """
 
+    start_ms = time.time() * 1000.0
+    stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
         ready_state = driver.execute_script("return document.readyState")
         if ready_state == u'complete':
             return True
         else:
+            now_ms = time.time() * 1000.0
+            if now_ms >= stop_ms:
+                break
             time.sleep(0.1)
     raise Exception(
         "Page elements never fully loaded after %s seconds!" % timeout)
@@ -393,6 +428,8 @@ def wait_for_and_switch_to_alert(driver, timeout=settings.LARGE_TIMEOUT):
     timeout - the time to wait for the alert in seconds
     """
 
+    start_ms = time.time() * 1000.0
+    stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
         try:
             alert = driver.switch_to.alert
@@ -400,5 +437,8 @@ def wait_for_and_switch_to_alert(driver, timeout=settings.LARGE_TIMEOUT):
             dummy_variable = alert.text  # noqa
             return alert
         except NoAlertPresentException:
+            now_ms = time.time() * 1000.0
+            if now_ms >= stop_ms:
+                break
             time.sleep(0.1)
     raise Exception("Alert was not present after %s seconds!" % timeout)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages  # noqa
 
 setup(
     name='seleniumbase',
-    version='1.1.49',
+    version='1.1.50',
     url='http://seleniumbase.com',
     author='Michael Mintz',
     author_email='@mintzworld',

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     license='The MIT License',
     install_requires=[
         'pip>=8.1.2',
+        'setuptools>=18.5',
         'selenium>=2.53.2',
         'nose==1.3.7',
         'pytest==2.9.1',
@@ -27,7 +28,7 @@ setup(
         'simplejson==3.8.2',
         'boto==2.40.0',
         'ipdb==0.10.0',
-        'pyvirtualdisplay==0.1.5',
+        'pyvirtualdisplay==0.2',
         ],
     packages=['seleniumbase',
               'seleniumbase.core',


### PR DESCRIPTION
The big thing here is that newer syntax will make the code more understandable to readers.
self.assert_element(ELEMENT) vs self.find_element(ELEMENT)
self.assert_text(TEXT, ELEMENT) vs self.find_text(TEXT, ELEMENT)
self.assert_link_text(LINK_TEXT) vs self.find_link_text(LINK_TEXT)
It wasn't clear with older methods what would happen if the element wasn't found.
In some cases, we just wanted an assert. The older methods will still return the element. Each version will fail if the element isn't found.
Older method names kept for backwards compatibility.