### PR TITLE
Add the non-terminating checks feature for tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,30 @@ self.execute_script("document.body.innerHTML = \"%s\"" % referral_link)
 self.click("a.analytics")  # Clicks the generated button
 ```
 
+#### Using non-terminating verifications:
+
+Let's say you want to verify multiple different elements on a web page in a single test, but you don't want the test to fail until you verified several elements at once so that you don't have to rerun the test to find more missing elements on the same page. That's where page checks come in. Here's the example:
+
+```python
+from seleniumbase import BaseCase
+
+class MyTestClass(BaseCase):
+
+    def test_non_terminating_checks(self):
+        self.open('http://xkcd.com/993/')
+        self.wait_for_element('#comic')
+        self.check_assert_element('img[alt="Brand Identity"]')
+        self.check_assert_element('img[alt="Rocket Ship"]')  # Will Fail
+        self.check_assert_element('#comicmap')
+        self.check_assert_text('Fake Item', '#middleContainer')  # Will Fail
+        self.check_assert_text('Random', '#middleContainer')
+        self.check_assert_element('a[name="Super Fake !!!"]')  # Will Fail
+        self.process_checks()
+```
+
+``check_assert_element()`` and ``check_assert_text()`` will save any exceptions that would be raised.
+To flush out all the failed checks into a single exception, make sure to call ``self.process_checks()`` at the end of your test method. If your test hits multiple pages, you can call ``self.process_checks()`` at the end of all your checks for a single page. This way, the screenshot from your log file will make the location where the checks were made.
+
 ### Part III: More Details
 
 Nosetests automatically runs any python method that starts with "test" from the file you selected. You can also select specific tests to run from files or classes. For example, the code in the early examples could've been run using "nosetests my_first_test.py:MyTestClass.test_basic ... ...". If you wanted to run all tests in MyTestClass, you can use: "nosetests my_first_test.py:MyTestClass ... ...", which is useful when you have multiple tests in the same file. Don't forget the plugins. Use "-s" if you want better logging in the console output.

--- a/examples/non_terminating_checks_test.py
+++ b/examples/non_terminating_checks_test.py
@@ -1,0 +1,15 @@
+from seleniumbase import BaseCase
+
+
+class MyTestClass(BaseCase):
+
+    def test_non_terminating_checks(self):
+        self.open('http://xkcd.com/993/')
+        self.wait_for_element('#comic')
+        self.check_assert_element('img[alt="Brand Identity"]')
+        self.check_assert_element('img[alt="Rocket Ship"]')  # Will Fail
+        self.check_assert_element('#comicmap')
+        self.check_assert_text('Fake Item', '#middleContainer')  # Will Fail
+        self.check_assert_text('Random', '#middleContainer')
+        self.check_assert_element('a[name="Super Fake !!!"]')  # Will Fail
+        self.process_checks()

--- a/help_docs/method_summary.md
+++ b/help_docs/method_summary.md
@@ -153,4 +153,14 @@ self.wait_for_and_dismiss_alert(timeout=settings.LARGE_TIMEOUT)
 self.wait_for_and_switch_to_alert(timeout=settings.LARGE_TIMEOUT)
 
 self.save_screenshot(name, folder=None)
+
+########
+
+self.check_assert_element(selector, by=By.CSS_SELECTOR,
+    timeout=settings.TINY_TIMEOUT)
+
+self.check_assert_text(text, selector, by=By.CSS_SELECTOR,
+    timeout=settings.TINY_TIMEOUT)
+
+self.process_checks()
 ```

--- a/seleniumbase/config/settings.py
+++ b/seleniumbase/config/settings.py
@@ -8,7 +8,8 @@ NOSETESTS USERS: IF YOU MAKE CHANGES TO THIS FILE, YOU NEED TO RERUN
 
 # #####>>>>>----- REQUIRED/IMPORTANT SETTINGS -----<<<<<#####
 
-# Default times to wait for page elements to appear before performing actions
+# Default seconds to wait for page elements to appear before performing actions
+TINY_TIMEOUT = 0.1
 SMALL_TIMEOUT = 5
 LARGE_TIMEOUT = 10
 EXTREME_TIMEOUT = 30

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -880,6 +880,14 @@ class BaseCase(unittest.TestCase):
         You'll need to add the following line to the subclass's tearDown():
         super(SubClassOfBaseCase, self).tearDown()
         """
+        if self.page_check_failures:
+            # self.process_checks() was not called after checks were made.
+            # We will log those now here, but without raising an exception.
+            exception_output = ''
+            exception_output += "\n*** FAILED CHECKS FOR: %s\n" % self.id()
+            for tb in self.page_check_failures:
+                exception_output += "%s\n" % tb
+            logging.exception(exception_output)
         if self.is_pytest:
             test_id = "%s.%s.%s" % (self.__class__.__module__,
                                     self.__class__.__name__,

--- a/seleniumbase/fixtures/page_actions.py
+++ b/seleniumbase/fixtures/page_actions.py
@@ -131,7 +131,7 @@ def hover_and_click(driver, hover_selector, click_selector,
                 break
             time.sleep(0.1)
     raise NoSuchElementException(
-        "Element [%s] was not present after %s seconds!" %
+        "Element {%s} was not present after %s seconds!" %
         (click_selector, timeout))
 
 
@@ -165,7 +165,7 @@ def wait_for_element_present(driver, selector, by=By.CSS_SELECTOR,
             time.sleep(0.1)
     if not element:
         raise NoSuchElementException(
-            "Element [%s] was not present after %s seconds!" % (
+            "Element {%s} was not present after %s seconds!" % (
                 selector, timeout))
 
 
@@ -204,11 +204,11 @@ def wait_for_element_visible(driver, selector, by=By.CSS_SELECTOR,
             time.sleep(0.1)
     if not element and by != By.LINK_TEXT:
         raise ElementNotVisibleException(
-            "Element [%s] was not visible after %s seconds!" % (
+            "Element {%s} was not visible after %s seconds!" % (
                 selector, timeout))
     if not element and by == By.LINK_TEXT:
         raise ElementNotVisibleException(
-            "Link text [%s] was not visible after %s seconds!" % (
+            "Link text {%s} was not visible after %s seconds!" % (
                 selector, timeout))
 
 
@@ -248,7 +248,7 @@ def wait_for_text_visible(driver, text, selector, by=By.CSS_SELECTOR,
             time.sleep(0.1)
     if not element:
         raise ElementNotVisibleException(
-            "Expected text [%s] for [%s] was not visible after %s seconds!" %
+            "Expected text {%s} for {%s} was not visible after %s seconds!" %
             (text, selector, timeout))
 
 
@@ -276,7 +276,7 @@ def wait_for_element_absent(driver, selector, by=By.CSS_SELECTOR,
             time.sleep(0.1)
         except Exception:
             return True
-    raise Exception("Element [%s] was still present after %s seconds!" %
+    raise Exception("Element {%s} was still present after %s seconds!" %
                     (selector, timeout))
 
 
@@ -308,7 +308,7 @@ def wait_for_element_not_visible(driver, selector, by=By.CSS_SELECTOR,
         except Exception:
             return True
     raise Exception(
-        "Element [%s] was still visible after %s seconds!" % (
+        "Element {%s} was still visible after %s seconds!" % (
             selector, timeout))
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages  # noqa
 
 setup(
     name='seleniumbase',
-    version='1.1.54',
+    version='1.1.55',
     url='http://seleniumbase.com',
     author='Michael Mintz',
     author_email='@mintzworld',


### PR DESCRIPTION
Ever wanted to check multiple elements on a page without having your test exit after the first failure? In this latest update to SeleniumBase, I bring you non-terminating checks! Here's how it works:

```python
from seleniumbase import BaseCase

class MyTestClass(BaseCase):

    def test_non_terminating_checks(self):
        self.open('http://xkcd.com/993/')
        self.wait_for_element('#comic')
        self.check_assert_element('img[alt="Brand Identity"]')
        self.check_assert_element('img[alt="Rocket Ship"]')  # Will Fail
        self.check_assert_element('#comicmap')
        self.check_assert_text('Fake Item', '#middleContainer')  # Will Fail
        self.check_assert_text('Random', '#middleContainer')
        self.check_assert_element('a[name="Super Fake !!!"]')  # Will Fail
        self.process_checks()
```
New methods ``self.check_assert_element()`` and ``self.check_assert_text()`` are like time-bomb assert statements. If any assertions from those fail, they won't be triggered until you call ``self.process_checks()`` at the end of your test. Now you'll know all your page failures instead of just the first one for each test when you use checks!