### PR TITLE
Update the multi-assert feature

### DIFF
--- a/examples/gui_test_runner.py
+++ b/examples/gui_test_runner.py
@@ -55,7 +55,7 @@ class App:
         self.run6 = Button(
             frame, command=self.run_6,
             text=("nosetests non_terminating_checks_test.py"
-                  " --with-selenium --demo_mode")).pack()
+                  " --with-selenium")).pack()
         self.title7 = Label(
             frame,
             text="MySQL DB Reporting Tests: (See ReadMe.md for Setup Steps!)",
@@ -91,8 +91,7 @@ class App:
 
     def run_6(self):
         os.system(
-            'nosetests non_terminating_checks_test.py'
-            ' --with-selenium --demo_mode')
+            'nosetests non_terminating_checks_test.py --with-selenium')
 
     def run_7(self):
         os.system(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pip>=8.1.2
 setuptools>=18.5
-selenium>=2.53.5
+selenium>=2.53.6
 nose==1.3.7
 pytest==2.9.1
 flake8==2.5.4

--- a/seleniumbase/config/settings.py
+++ b/seleniumbase/config/settings.py
@@ -10,6 +10,7 @@ NOSETESTS USERS: IF YOU MAKE CHANGES TO THIS FILE, YOU NEED TO RERUN
 
 # Default seconds to wait for page elements to appear before performing actions
 TINY_TIMEOUT = 0.1
+MINI_TIMEOUT = 2
 SMALL_TIMEOUT = 5
 LARGE_TIMEOUT = 10
 EXTREME_TIMEOUT = 30

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -707,7 +707,7 @@ class BaseCase(unittest.TestCase):
                     self.page_check_count, current_url, message))
 
     def check_assert_element(self, selector, by=By.CSS_SELECTOR,
-                             timeout=settings.TINY_TIMEOUT):
+                             timeout=settings.MINI_TIMEOUT):
         """ A non-terminating assertion for an element on a page.
             Any and all exceptions will be saved until the process_checks()
             method is called from inside a test, likely at the end of it. """
@@ -720,7 +720,7 @@ class BaseCase(unittest.TestCase):
             return False
 
     def check_assert_text(self, text, selector, by=By.CSS_SELECTOR,
-                          timeout=settings.TINY_TIMEOUT):
+                          timeout=settings.MINI_TIMEOUT):
         """ A non-terminating assertion for text from an element on a page.
             Any and all exceptions will be saved until the process_checks()
             method is called from inside a test, likely at the end of it. """

--- a/server_requirements.txt
+++ b/server_requirements.txt
@@ -1,6 +1,6 @@
 pip>=8.1.2
 setuptools>=18.5
-selenium>=2.53.5
+selenium>=2.53.6
 nose==1.3.7
 pytest==2.9.1
 flake8==2.5.4

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         'pip>=8.1.2',
         'setuptools>=18.5',
-        'selenium>=2.53.5',
+        'selenium>=2.53.6',
         'nose==1.3.7',
         'pytest==2.9.1',
         'flake8==2.5.4',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages  # noqa
 
 setup(
     name='seleniumbase',
-    version='1.1.61',
+    version='1.1.62',
     url='http://seleniumbase.com',
     author='Michael Mintz',
     author_email='@mintzworld',


### PR DESCRIPTION
The multi-assert feature allows you to assert multiple elements at the same time and have all the failing assertions fail together so that you can find all the problems on a page at one time without having to rerun the test after fixing each individual issue.